### PR TITLE
Truncate logs that exceed GitHub.com's max length

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ and set up the configuration file for the application.
 
 | Property        | Description                                                                                                                                         |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| TRAVIS_URL      | The Travis CI api endpoint that applies to your application (either .com or .org)                                                                   |
+| TRAVIS_DOMAIN   | The Travis CI domain that applies to your application (either `travis-ci.com` or `travis-ci.org`)                                                                   |
 | COMMENT_ENV_VAR | An environment variable used in your Travis CI build matrix that serves as a flag for whether or not the job's log should be parsed as a PR comment |
 | GH_TOKEN        | The Personal Access Token created in Configuration Step 2, above                                                                                    |
 | ORG             | The GitHub organization/owner of the main repository (this project's ORG would be "bobholt")                                                        |

--- a/config.sample.txt
+++ b/config.sample.txt
@@ -1,8 +1,8 @@
 [Travis]
 # Make sure you use the correct config URL, the .org and .com
 # have different keys!
-# TRAVIS_URL = https://api.travis-ci.com
-TRAVIS_URL = https://api.travis-ci.org
+# TRAVIS_DOMAIN = travis-ci.com
+TRAVIS_DOMAIN = travis-ci.org
 COMMENT_ENV_VAR = COMMENT_BOT
 
 [GitHub]

--- a/log_parser.py
+++ b/log_parser.py
@@ -15,8 +15,8 @@ from collections import OrderedDict
 
 def parse_logs(logs):
     """Extract and return relevant info from log."""
-    comments = {}
-    for title, log in logs.iteritems():
+    comments = []
+    for log in logs:
 
         # The log currently duplicates each line in the log.
         # Split the lines, convert to an OrderedDict to remove
@@ -24,7 +24,7 @@ def parse_logs(logs):
         # list.
         # Note: This may incorrectly assume there are no duplications
         #       that we _do_ want.
-        log_lines = list(OrderedDict.fromkeys(log.splitlines()))
+        log_lines = list(OrderedDict.fromkeys(log['data'].splitlines()))
         comment_lines = []
         for line in log_lines:
             if ':check_stability:' in line and 'DEBUG:' not in line:
@@ -42,5 +42,9 @@ def parse_logs(logs):
                               '\n'.join(comment_lines),
                               flags=re.MULTILINE)
 
-        comments[title] = comment_text
+        comments.append({
+            'job_id': log['job_id'],
+            'title': log['title'],
+            'text': comment_text
+        })
     return comments

--- a/test.py
+++ b/test.py
@@ -7,43 +7,50 @@ class LogParserTestCase(unittest.TestCase):
     """Test case for log_parser module."""
 
     def test_empty_dict(self):
-        self.assertEqual(parse_logs({}),
-                         {},
-                         'It should return an empty dict if passed an empty dict.')
+        self.assertEqual(parse_logs([]),
+                         [],
+                         'It should return an empty dict if passed an empty list.')
 
     def test_non_debug_level(self):
-        self.assertEqual(parse_logs({'firefox': 'ABCDE:check_stability:Hello World'}),
-                         {'firefox': 'Hello World'},
+        self.assertEqual(parse_logs([{'job_id': 3, 'title': 'firefox', 'data': 'ABCDE:check_stability:Hello World'}]),
+                         [{'job_id': 3, 'title': 'firefox', 'text': 'Hello World'}],
                          'It should include non-debug log statements that include ":check_stability:".')
 
     def test_debug_level(self):
-        self.assertEqual(parse_logs({'firefox': 'DEBUG:check_stability:Hello World'}),
-                         {'firefox': ''},
+        self.assertEqual(parse_logs([{'job_id': 5, 'title': 'firefox', 'data': 'DEBUG:check_stability:Hello World'}]),
+                         [{'job_id': 5, 'title': 'firefox', 'text': ''}],
                          'It should exclude debug log statements that include ":check_stability:".')
 
     def test_non_check_stability(self):
-        self.assertEqual(parse_logs({'firefox': 'Hello World!'}),
-                         {'firefox': ''},
+        self.assertEqual(parse_logs([{'job_id': 8, 'title': 'firefox', 'data': 'Hello World!'}]),
+                         [{'job_id': 8, 'title': 'firefox', 'text': ''}],
                          'It should exclude lines that do not include ":check_stability:"')
 
     def test_multi_line(self):
-        self.assertEqual(parse_logs({'firefox': 'Hello World!\nERROR:check_stability:Goodbye Cruel World!'}),
-                         {'firefox': 'Goodbye Cruel World!'},
+        self.assertEqual(parse_logs([{'job_id': 9, 'title': 'firefox', 'data': 'Hello World!\nERROR:check_stability:Goodbye Cruel World!'}]),
+                         [{'job_id': 9, 'title': 'firefox', 'text': 'Goodbye Cruel World!'}],
                          'It should include and exclude correctly across multiple lines.')
 
     def test_multi_logs(self):
-        self.assertEqual(parse_logs({
-                                    'firefox': 'INFO:check_stability:Hello World!\nDEBUG:check_stability:Goodbye Cruel World!',
-                                    'chrome': 'DEBUG:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'
-                                    }),
-                         {'firefox': 'Hello World!', 'chrome': 'Goodbye Cruel World!'},
+        self.assertEqual(parse_logs([
+                                    {'job_id': 94, 'title': 'firefox', 'data': 'INFO:check_stability:Hello World!\nDEBUG:check_stability:Goodbye Cruel World!'},
+                                    {'job_id': 32, 'title': 'chrome', 'data': 'DEBUG:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'}
+                                    ]),
+                         [
+                             {'job_id': 94, 'title': 'firefox', 'text': 'Hello World!'},
+                             {'job_id': 32, 'title': 'chrome', 'text': 'Goodbye Cruel World!'}
+                         ],
                          'It should include and exclude correctly across multiple logs.')
 
     def test_new_line(self):
-        self.assertEqual(parse_logs({'firefox': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!',
-                                     'chrome': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'}),
-                         {'firefox': 'Hello World!\nGoodbye Cruel World!',
-                          'chrome': 'Hello World!\nGoodbye Cruel World!'},
+        self.assertEqual(parse_logs([
+                                    {'job_id': 83, 'title': 'firefox', 'data': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'},
+                                    {'job_id': 88, 'title': 'chrome', 'data': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'}
+                                    ]),
+                         [
+                             {'job_id': 83, 'title': 'firefox', 'text': 'Hello World!\nGoodbye Cruel World!'},
+                             {'job_id': 88, 'title': 'chrome', 'text': 'Hello World!\nGoodbye Cruel World!'}
+                         ],
                          'It should include newline characters as appropriate.')
 
 if __name__ == '__main__':

--- a/travis.py
+++ b/travis.py
@@ -15,7 +15,7 @@ from OpenSSL.crypto import Error as SignatureError
 
 CONFIG = ConfigParser.ConfigParser()
 CONFIG.readfp(open(r'config.txt'))
-TRAVIS_URL = CONFIG.get('Travis', 'TRAVIS_URL')
+TRAVIS_DOMAIN = CONFIG.get('Travis', 'TRAVIS_DOMAIN')
 COMMENT_ENV_VAR = CONFIG.get('Travis', 'COMMENT_ENV_VAR')
 
 
@@ -31,9 +31,14 @@ class Travis(object):
 
     """Interface to GitHub API."""
 
+    @statimethod
+    def job_url(org_name, repo_name, job_id):
+        return 'https://%s/%s/%s/jobs/%s' % (
+                TRAVIS_DOMAIN, org_name, repo_name, job_id)
+
     def __init__(self):
         """Create Travis instance."""
-        self.base_url = TRAVIS_URL
+        self.base_url = 'https://api.%' % TRAVIS_DOMAIN
 
     def get_job_log(self, job_id):
         """Retrieve and return log from Travis CI API."""
@@ -49,7 +54,7 @@ class Travis(object):
             return {}
 
         jobs = payload.get('matrix')
-        logs = {}
+        logs = []
 
         for job in jobs:
             config = job.get('config', {})
@@ -57,9 +62,13 @@ class Travis(object):
             for variable in env:
                 if COMMENT_ENV_VAR in variable:
                     job_id = job.get('id')
-                    log = self.get_job_log(job_id)
-                    logs[variable.partition('=')[2]] = log
+                    logs.append({
+                        'job_id': job_id
+                        'title': variable.partition('=')[2],
+                        'data': self.get_job_log(job_id)
+                    })
                     break
+
         return logs
 
     def get_public_key(self):

--- a/webhook_handler.py
+++ b/webhook_handler.py
@@ -32,11 +32,13 @@ def webhook_handler(payload, signature):
     comments = parse_logs(logs)
 
     # Create a separate comment for every job
-    for title, comment in comments.iteritems():
+    for comment in comments:
         try:
+            log_url = Travis.job_url(github.org, github.repo, comment['build_id'])
             github.post_comment(issue_number,
-                                comment,
-                                title)
+                                comment['text'],
+                                comment['title'],
+                                log_url)
         except requests.RequestException as err:
             logging.error(err.response.text)
             return err.response.text, 500


### PR DESCRIPTION
Bob: last night, I wrote a patch for https://github.com/w3c/web-platform-tests/issues/4550 -- see it here: https://github.com/w3c/web-platform-tests/pull/4684 . This morning, I realized that GitHub.com enforces a limit of its own, so I amended that patch and submitted a new version here: https://github.com/w3c/web-platform-tests/pull/4697.  IF landed before [your patch to remove the GitHub-specific code from web-platform-tests](https://github.com/w3c/web-platform-tests/pull/4651), it will cause conflicts. I think those are pretty trivial and should be easy enough to resolve.

The new functionality is more concerning. Since I'm the troublemaker, I decided the responsibility to re-implement fell on me. While the tests pass, I did *not* do my due diligence in functional testing this change. I know you already have this running against your own profiles on GitHub.com/Travis-ci.com, so I was wondering: would you mind performing a functional test for me?

If all goes well, this should still probably wait until the aforementioned https://github.com/w3c/web-platform-tests/pull/4684 is merged.

Commit message:

> Truncate logs that exceed GitHub.com's max length
>
> GitHub.com enforces a limit on comments' total character count; comments
> posted to the API that exceed this limit are rejected. Truncate
> overly-long log data prior to submitting to GitHub.com and prefix the
> modified comment with a message that explains the modification.