### PR TITLE
fix commenting bug in prbuildbot

### DIFF
--- a/github.py
+++ b/github.py
@@ -109,10 +109,8 @@ class GitHub(object):
         data = {"body": body}
         for comment in comments:
             if (comment["user"]["login"] == user["login"] and
-                    comment["body"].startswith(title_line)):
+                    title_line in comment["body"]):
                 comment_url = urljoin(self.base_url,
                                       "issues/comments/%s" % comment["id"])
-                self.patch(comment_url, data)
-                break
-            else:
-                self.post(issue_comments_url, data)
+                return self.patch(comment_url, data)
+        return self.post(issue_comments_url, data)


### PR DESCRIPTION
cc @sideshowbarker

I made a [late-breaking change](https://github.com/w3c/prbuildbot/commit/494a877db4708d220188ba8c88cb85fbdffd780f) before transferring the repo yesterday and tricked myself into thinking that it worked when running in my own fork. Turns out it didn't. This is the fix. 

This should resolve the issue with the comments not appearing as well as the duplicate comments when they do appear. 