### PR TITLE
do not remove duplicate log lines

### DIFF
--- a/log_parser.py
+++ b/log_parser.py
@@ -18,13 +18,7 @@ def parse_logs(logs):
     comments = {}
     for title, log in logs.iteritems():
 
-        # The log currently duplicates each line in the log.
-        # Split the lines, convert to an OrderedDict to remove
-        # duplicates while maintaining order, and turn it back into a
-        # list.
-        # Note: This may incorrectly assume there are no duplications
-        #       that we _do_ want.
-        log_lines = list(OrderedDict.fromkeys(log.splitlines()))
+        log_lines = log.splitlines()
         comment_lines = []
         for line in log_lines:
             if ':check_stability:' in line and 'DEBUG:' not in line:


### PR DESCRIPTION
- this fixes the issue where multiple test output tables were ill-formatted
- the existing code was to fix an issue where all lines were duplicated in travis logs
- @jugglinmike fixed the root cause of the duplcation in the `/tools` directory

You can see the fix working in my test branch: https://github.com/bobholt/web-platform-tests/pull/5