### PR TITLE
add links to log comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ and set up the configuration file for the application.
 
 | Property        | Description                                                                                                                                         |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| TRAVIS_URL      | The Travis CI api endpoint that applies to your application (either .com or .org)                                                                   |
+| TRAVIS_DOMAIN      | The Travis CI domain that applies to your application (either `travis-ci.com` or `travis-ci.org`)                                                                   |
 | COMMENT_ENV_VAR | An environment variable used in your Travis CI build matrix that serves as a flag for whether or not the job's log should be parsed as a PR comment |
 | GH_TOKEN        | The Personal Access Token created in Configuration Step 2, above                                                                                    |
 | ORG             | The GitHub organization/owner of the main repository (this project's ORG would be "bobholt")                                                        |

--- a/config.sample.txt
+++ b/config.sample.txt
@@ -1,8 +1,8 @@
 [Travis]
 # Make sure you use the correct config URL, the .org and .com
 # have different keys!
-# TRAVIS_URL = https://api.travis-ci.com
-TRAVIS_URL = https://api.travis-ci.org
+# TRAVIS_DOMAIN = travis-ci.com
+TRAVIS_DOMAIN = travis-ci.org
 COMMENT_ENV_VAR = COMMENT_BOT
 
 [GitHub]

--- a/github.py
+++ b/github.py
@@ -99,14 +99,15 @@ class GitHub(object):
         resp.raise_for_status()
         return resp
 
-    def post_comment(self, issue_number, body, title):
+    def post_comment(self, issue_number, body, title, full_log_url):
         """Create or update comment in pull request comment section."""
         user = self.get(urljoin(self.base_url, "/user")).json()
         issue_comments_url = urljoin(self.base_url,
                                      "issues/%s/comments" % issue_number)
         comments = self.get(issue_comments_url).json()
         title_line = format_comment_title(title)
-        data = {"body": body}
+        link = ' [View the complete job log.](%s)' % full_log_url
+        data = {"body": "%s\n\n%s" % (link, body)}
         for comment in comments:
             if (comment["user"]["login"] == user["login"] and
                     title_line in comment["body"]):

--- a/log_parser.py
+++ b/log_parser.py
@@ -10,15 +10,14 @@ The following example parses the logs for w3c/web-platform-tests.
 """
 
 import re
-from collections import OrderedDict
 
 
 def parse_logs(logs):
     """Extract and return relevant info from log."""
-    comments = {}
-    for title, log in logs.iteritems():
+    comments = []
+    for log in logs:
 
-        log_lines = log.splitlines()
+        log_lines = log['data'].splitlines()
         comment_lines = []
         for line in log_lines:
             if ':check_stability:' in line and 'DEBUG:' not in line:
@@ -36,5 +35,9 @@ def parse_logs(logs):
                               '\n'.join(comment_lines),
                               flags=re.MULTILINE)
 
-        comments[title] = comment_text
+        comments.append({
+            'job_id': log['job_id'],
+            'title': log['title'],
+            'text': comment_text
+        })
     return comments

--- a/test.py
+++ b/test.py
@@ -7,43 +7,50 @@ class LogParserTestCase(unittest.TestCase):
     """Test case for log_parser module."""
 
     def test_empty_dict(self):
-        self.assertEqual(parse_logs({}),
-                         {},
-                         'It should return an empty dict if passed an empty dict.')
+        self.assertEqual(parse_logs([]),
+                         [],
+                         'It should return an empty dict if passed an empty list.')
 
     def test_non_debug_level(self):
-        self.assertEqual(parse_logs({'firefox': 'ABCDE:check_stability:Hello World'}),
-                         {'firefox': 'Hello World'},
+        self.assertEqual(parse_logs([{'job_id': 3, 'title': 'firefox', 'data': 'ABCDE:check_stability:Hello World'}]),
+                         [{'job_id': 3, 'title': 'firefox', 'text': 'Hello World'}],
                          'It should include non-debug log statements that include ":check_stability:".')
 
     def test_debug_level(self):
-        self.assertEqual(parse_logs({'firefox': 'DEBUG:check_stability:Hello World'}),
-                         {'firefox': ''},
+        self.assertEqual(parse_logs([{'job_id': 5, 'title': 'firefox', 'data': 'DEBUG:check_stability:Hello World'}]),
+                         [{'job_id': 5, 'title': 'firefox', 'text': ''}],
                          'It should exclude debug log statements that include ":check_stability:".')
 
     def test_non_check_stability(self):
-        self.assertEqual(parse_logs({'firefox': 'Hello World!'}),
-                         {'firefox': ''},
+        self.assertEqual(parse_logs([{'job_id': 8, 'title': 'firefox', 'data': 'Hello World!'}]),
+                         [{'job_id': 8, 'title': 'firefox', 'text': ''}],
                          'It should exclude lines that do not include ":check_stability:"')
 
     def test_multi_line(self):
-        self.assertEqual(parse_logs({'firefox': 'Hello World!\nERROR:check_stability:Goodbye Cruel World!'}),
-                         {'firefox': 'Goodbye Cruel World!'},
+        self.assertEqual(parse_logs([{'job_id': 9, 'title': 'firefox', 'data': 'Hello World!\nERROR:check_stability:Goodbye Cruel World!'}]),
+                         [{'job_id': 9, 'title': 'firefox', 'text': 'Goodbye Cruel World!'}],
                          'It should include and exclude correctly across multiple lines.')
 
     def test_multi_logs(self):
-        self.assertEqual(parse_logs({
-                                    'firefox': 'INFO:check_stability:Hello World!\nDEBUG:check_stability:Goodbye Cruel World!',
-                                    'chrome': 'DEBUG:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'
-                                    }),
-                         {'firefox': 'Hello World!', 'chrome': 'Goodbye Cruel World!'},
+        self.assertEqual(parse_logs([
+                                    {'job_id': 94, 'title': 'firefox', 'data': 'INFO:check_stability:Hello World!\nDEBUG:check_stability:Goodbye Cruel World!'},
+                                    {'job_id': 32, 'title': 'chrome', 'data': 'DEBUG:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'}
+                                    ]),
+                         [
+                             {'job_id': 94, 'title': 'firefox', 'text': 'Hello World!'},
+                             {'job_id': 32, 'title': 'chrome', 'text': 'Goodbye Cruel World!'}
+                         ],
                          'It should include and exclude correctly across multiple logs.')
 
     def test_new_line(self):
-        self.assertEqual(parse_logs({'firefox': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!',
-                                     'chrome': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'}),
-                         {'firefox': 'Hello World!\nGoodbye Cruel World!',
-                          'chrome': 'Hello World!\nGoodbye Cruel World!'},
+        self.assertEqual(parse_logs([
+                                    {'job_id': 83, 'title': 'firefox', 'data': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'},
+                                    {'job_id': 88, 'title': 'chrome', 'data': 'INFO:check_stability:Hello World!\nWARNING:check_stability:Goodbye Cruel World!'}
+                                    ]),
+                         [
+                             {'job_id': 83, 'title': 'firefox', 'text': 'Hello World!\nGoodbye Cruel World!'},
+                             {'job_id': 88, 'title': 'chrome', 'text': 'Hello World!\nGoodbye Cruel World!'}
+                         ],
                          'It should include newline characters as appropriate.')
 
 if __name__ == '__main__':

--- a/webhook_handler.py
+++ b/webhook_handler.py
@@ -32,11 +32,14 @@ def webhook_handler(payload, signature):
     comments = parse_logs(logs)
 
     # Create a separate comment for every job
-    for title, comment in comments.iteritems():
+    for comment in comments:
         try:
+            log_url = Travis.job_url(github.org, github.repo,
+                                     comment['job_id'])
             github.post_comment(issue_number,
-                                comment,
-                                title)
+                                comment['text'],
+                                comment['title'],
+                                log_url)
         except requests.RequestException as err:
             logging.error(err.response.text)
             return err.response.text, 500


### PR DESCRIPTION
This takes the log-linking functionality from @jugglinmike's [truncation PR](https://github.com/w3c/prbuildbot/pull/2) and applies it to all comments.

Fixes #6 

Example output:
![link](https://cloud.githubusercontent.com/assets/94167/22786397/55260480-eea6-11e6-935c-336cd0229f43.png)

