### PR TITLE
remove payload logging

### DIFF
--- a/travis.py
+++ b/travis.py
@@ -74,7 +74,6 @@ class Travis(object):
 
     def get_verified_payload(self, payload, signature):
         """Verify payload with Travis CI signature and public key."""
-        logging.debug("Payload: %s", payload)
         decoded_signature = base64.b64decode(signature)
         try:
             public_key = self.get_public_key()


### PR DESCRIPTION
This was included for development, and is largely unnecessary for debugging day-to-day issues with the bot. It just bloats the file.

@sideshowbarker: It might be worth purging the prbuildbot.log on the server now and from time-to-time. It's probably already huge.