### PR TITLE
comment on lint errors in build

### DIFF
--- a/github.py
+++ b/github.py
@@ -108,6 +108,8 @@ class GitHub(object):
                                      "issues/%s/comments" % issue_number)
         comments = self.get(issue_comments_url).json()
         title_line = format_comment_title(title)
+        if title_line not in body:
+            body = "%s\n\n%s" % (title_line, body)
         body = ' [View the complete job log.](%s)\n\n%s' % (full_log_url, body)
 
         if len(body) > self.max_comment_length:

--- a/log_parser.py
+++ b/log_parser.py
@@ -19,8 +19,9 @@ def parse_logs(logs):
 
         log_lines = log['data'].splitlines()
         comment_lines = []
+        match_regex = r'^([A-Z])+(:check_stability:|:lint:)'
         for line in log_lines:
-            if ':check_stability:' in line and 'DEBUG:' not in line:
+            if re.search(match_regex, line) and 'DEBUG:' not in line:
 
                 # Add a newline before the Subtest Results table
                 # There's probably a more robust way to do this check.
@@ -30,10 +31,13 @@ def parse_logs(logs):
 
         # Remove the <LOG_LEVEL>:check_stability: strings at the
         # beginning of every line
-        comment_text = re.sub(r'^([A-Z])+:check_stability:',
+        comment_text = re.sub(match_regex,
                               '',
                               '\n'.join(comment_lines),
                               flags=re.MULTILINE)
+
+        if log['title'] == 'lint' and len(comment_text) == 0:
+            comment_text = 'Passed'
 
         comments.append({
             'job_id': log['job_id'],

--- a/travis.py
+++ b/travis.py
@@ -62,12 +62,13 @@ class Travis(object):
             config = job.get('config', {})
             env = config.get('env', [])
             for variable in env:
-                title_match = re.search(r"%s=([\w:]+)" % COMMENT_ENV_VAR, variable)
-                if title_match:
+                build_job_match = re.search(r"%s=([\w:]+)" % COMMENT_ENV_VAR, variable)
+                lint_job_match = re.search(r"(lint)", variable)
+                if build_job_match or lint_job_match:
                     job_id = job.get('id')
                     logs.append({
                         'job_id': job_id,
-                        'title': title_match.group(1),
+                        'title': (build_job_match or lint_job_match).group(1),
                         'data': self.get_job_log(job_id)
                     })
                     break


### PR DESCRIPTION
This depends on the successful merge of https://github.com/w3c/wpt-tools/pull/190.

This causes the comment bot to parse lint log output and comment either "Passed" or the lint errors as demonstrated at https://github.com/bobholt/web-platform-tests/pull/11#issuecomment-291145243.