### PR TITLE
Don't add a comment for lint jobs when the job passes.

### DIFF
--- a/log_parser.py
+++ b/log_parser.py
@@ -36,8 +36,9 @@ def parse_logs(logs):
                               '\n'.join(comment_lines),
                               flags=re.MULTILINE)
 
+        # Don't comment on passing lint jobs
         if log['title'] == 'lint' and len(comment_text) == 0:
-            comment_text = 'Passed'
+            continue
 
         comments.append({
             'job_id': log['job_id'],


### PR DESCRIPTION
This helps reduce the number of bot comments on PRs in the common case.