### PR TITLE
allow extra stuff in log strings

### DIFF
--- a/log_parser.py
+++ b/log_parser.py
@@ -19,7 +19,7 @@ def parse_logs(logs):
 
         log_lines = log['data'].splitlines()
         comment_lines = []
-        match_regex = r'^([A-Z])+(:check_stability:|:lint:)'
+        match_regex = r'^([A-Z])+(:.*check_stability:|:lint:)'
         for line in log_lines:
             if re.search(match_regex, line) and 'DEBUG:' not in line:
 


### PR DESCRIPTION
The full path to `check_stability` was added to the logs (e.g. `INFO:/home/travis/build/w3c/web-platform-tests/tools/ci/check_stability:`), but the buildbot only looked for things like `INFO:check_stability:`. This adds an allowance for 0-any number characters between the opening colon and `check_stability`.